### PR TITLE
Changing draft_recipient_ids to be text instead of string

### DIFF
--- a/db/migrate/20130419055252_setup_discuss.rb
+++ b/db/migrate/20130419055252_setup_discuss.rb
@@ -6,7 +6,7 @@ class SetupDiscuss < ActiveRecord::Migration
       t.text        :body
       t.integer     :user_id
       t.string      :ancestry
-      t.string      :draft_recipient_ids
+      t.text        :draft_recipient_ids
       t.datetime    :sent_at
       t.datetime    :received_at
       t.datetime    :read_at


### PR DESCRIPTION
I think if we make this column text it would allow for more recipients without breaking the 255 string db constraint. 
