### PR TITLE
adding in case for when draft but no recipients selected.

### DIFF
--- a/app/models/discuss/message.rb
+++ b/app/models/discuss/message.rb
@@ -44,7 +44,11 @@ module Discuss
     end
 
     def sender
-      sent? ? user : parent.user
+      if sent?
+        user
+      else
+        parent ? parent.user : user
+      end
     end
 
     def recipients

--- a/test/unit/discuss/message_test.rb
+++ b/test/unit/discuss/message_test.rb
@@ -20,6 +20,18 @@ module Discuss
       assert_equal timestamp, received.read_at, 'read_at timestamp should not change'
     end
 
+
+    context "draft" do
+      it 'returns proper user depending if there are recipients' do
+        m = Message.new(body: 'abc', user_id: 1)
+        assert_equal m.unsent?, true
+        assert_equal m.sender, User.first
+
+        m.update(draft_recipient_ids: [2,3])
+        assert_equal m.sender, User.first
+      end
+    end
+
     context 'with users' do
       it 'should have a user' do
         message = @sender.messages.new


### PR DESCRIPTION
Hello Elle (:heart:),

This PR is for when creating a draft message, and not selecting any recipients it would break by calling `messgae.sender` in the view -- so this allows things to work correctly.  If you can have a double look at it and let me know your thoughts, that would be great!

Hope all is well,
